### PR TITLE
Fix license on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A faktory worker framework for node apps",
   "main": "index.js",
   "author": "Josh Bielick <jbielick@gmail.com>",
-  "license": "GPL-3.0",
+  "license": "MIT",
   "scripts": {
     "test": "nyc --cache ava --serial",
     "coverage": "nyc report --reporter=html",


### PR DESCRIPTION
The LICENSE file on the git is MIT, but not in package.json (fossa.com was not happy :))
Or this difference is for an reason ?